### PR TITLE
added parcelLab params as redirectable GET params

### DIFF
--- a/src/configuration.php
+++ b/src/configuration.php
@@ -632,6 +632,9 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
             'utm_campaign',
             'utm_term',
             'utm_content',
+            'courier',
+            'trackingNo',
+            'lang',
         );
         $this->html_tags               = '';
 


### PR DESCRIPTION
These GET parameters are used by [parcelLab](https://parcellab.com/) and needed in order to be able to show a parcelLab tracking page on Shopgate.