### PR TITLE
LIBRARY-169 Zend-json lib version fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.3",
-    "zendframework/zend-json": "2.2.*"
+    "zendframework/zend-json": "~2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.3",
-    "zendframework/zend-json": "~2.6"
+    "zendframework/zend-json": "~2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"


### PR DESCRIPTION
This is needed for mage2 dependency support, else we cannot update the library there

This change was confirmed by Timo via [slack](https://shopgate.slack.com/archives/C0TNE8AHF/p1515401629000055)