### PR TITLE
Fix encoding on php 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- the "force_source_encoding" flag is now set to true by default, assuming the source encoding to be UTF-8 and effectively disabling auto-detection (*)
+- removed UTF-16LE from the list of possible source encodings (*)
+
+### Fixed
+- detection of ISO-8859-1 compatible strings as UTF-16LE, leading to them becoming strings with Japanese characters after conversion to UTF-8
+
+(*) These changes were made after a change in PHP 8.1's mb_string library made auto-detection work differently.
+    The assumed source encoding can be set via the "encoding" setting of the SDK if you need something different from UTF-8.
+    If you need auto-detection back, set "force_source_encoding" back to 0/false.
+
 ## [2.9.89] - 2022-04-12
 ### Fixed
 - setting an invoice or delivery address of `null` on a `ShopgateCartBase` object results in a fatal PHP error

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -544,7 +544,7 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
         $this->enable_default_redirect        = false;
         $this->encoding                       = 'UTF-8';
         $this->export_convert_encoding        = true;
-        $this->force_source_encoding          = false;
+        $this->force_source_encoding          = true;
         $this->supported_fields_check_cart    = array();
         $this->supported_fields_get_settings  = array();
         $this->supported_methods_cron         = array();

--- a/src/core.php
+++ b/src/core.php
@@ -1114,7 +1114,6 @@ abstract class ShopgateObject
         'ASCII',
         'CP1252',
         'ISO-8859-15',
-        'UTF-16LE',
         'ISO-8859-1',
     );
 


### PR DESCRIPTION
## Description

Auto-detection of string encoding has changed in PHP 8.1, detecting even some valid ASCII strings as UTF-16LE sequences, in which they represent Japanese characters.

I removed UTF-16LE from the list of possible source encodings for auto-detection because it's practically been irrelevant. Due to other issues with auto-detection (e.g. telling ISO-8859-15 from CP-1252) I disabled auto-detection by setting the `force_source_encoding` configuration to `true` by default. This will only affect new installations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
