### PR TITLE
Add proper container for external order coupons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- class `ShopgateExternalOrderExternalCoupon`, representing external coupons in the [get_orders documentation](http://developers.shopgate.com/plugin_api/orders/get_orders.html)
+
+### Changed
+- `ShopgateExternalOrder::setExternalCoupons()` now takes a list of `ShopgateExternalOrderExternalCoupon` objects; `ShopgateExternalCoupon` will still work but is deprecated
+
 ## [2.9.89] - 2022-04-12
 ### Fixed
 - setting an invoice or delivery address of `null` on a `ShopgateCartBase` object results in a fatal PHP error

--- a/src/customers.php
+++ b/src/customers.php
@@ -236,7 +236,7 @@ class ShopgateCustomer extends ShopgateContainer
      */
     public function setCustomFields($value)
     {
-        $this->custom_fields = $this->convertArrayToSubentityList($value, 'ShopgateOrderCustomField');
+        $this->custom_fields = $this->convertArrayToSubEntityList($value, 'ShopgateOrderCustomField');
     }
 
     /**
@@ -252,7 +252,7 @@ class ShopgateCustomer extends ShopgateContainer
      */
     public function setAddresses($value)
     {
-        $this->addresses = $this->convertArrayToSubentityList($value, 'ShopgateAddress');
+        $this->addresses = $this->convertArrayToSubEntityList($value, 'ShopgateAddress');
     }
 
 
@@ -729,7 +729,7 @@ class ShopgateAddress extends ShopgateContainer
      */
     public function setCustomFields($value)
     {
-        $this->custom_fields = $this->convertArrayToSubentityList($value, 'ShopgateOrderCustomField');
+        $this->custom_fields = $this->convertArrayToSubEntityList($value, 'ShopgateOrderCustomField');
     }
 
 

--- a/src/external_orders.php
+++ b/src/external_orders.php
@@ -928,7 +928,8 @@ class ShopgateExternalOrderTax extends ShopgateContainer
     }
 }
 
-class ShopgateExternalOrderExternalCoupon extends ShopgateContainer {
+class ShopgateExternalOrderExternalCoupon extends ShopgateContainer
+{
     protected $code;
     protected $order_index;
     protected $name;

--- a/src/external_orders.php
+++ b/src/external_orders.php
@@ -156,7 +156,7 @@ class ShopgateExternalOrder extends ShopgateContainer
      */
     public function setCustomFields($value)
     {
-        $this->custom_fields = $this->convertArrayToSubentityList($value, 'ShopgateOrderCustomField');
+        $this->custom_fields = $this->convertArrayToSubEntityList($value, 'ShopgateOrderCustomField');
     }
 
     /**
@@ -198,11 +198,15 @@ class ShopgateExternalOrder extends ShopgateContainer
     }
 
     /**
-     * @param ShopgateExternalCoupon[]|array<string, mixed>[] $value
+     * Before v2.9.90 $value was expected to be a ShopgateExternalCoupon. This is still working but deprecated, as the
+     * object differs vastly from what the documentation for the get_orders response requires. It is strongly
+     * recommended to switch to ShopgateExternalOrderExternalCoupon objects instead.
+     *
+     * @param ShopgateExternalOrderExternalCoupon[]|array<string, mixed>[] $value
      */
     public function setExternalCoupons($value)
     {
-        $this->external_coupons = $this->convertArrayToSubentityList($value, 'ShopgateExternalCoupon');
+        $this->external_coupons = $this->convertArrayToSubEntityList($value, array('ShopgateExternalOrderExternalCoupon', 'ShopgateExternalCoupon'));
     }
 
     /**
@@ -300,7 +304,7 @@ class ShopgateExternalOrder extends ShopgateContainer
      */
     public function setDeliveryNotes($value)
     {
-        $this->delivery_notes = $this->convertArrayToSubentityList($value, 'ShopgateDeliveryNote');
+        $this->delivery_notes = $this->convertArrayToSubEntityList($value, 'ShopgateDeliveryNote');
     }
 
     /**
@@ -308,7 +312,7 @@ class ShopgateExternalOrder extends ShopgateContainer
      */
     public function setOrderTaxes($value)
     {
-        $this->order_taxes = $this->convertArrayToSubentityList($value, 'ShopgateExternalOrderTax');
+        $this->order_taxes = $this->convertArrayToSubEntityList($value, 'ShopgateExternalOrderTax');
     }
 
     /**
@@ -316,7 +320,7 @@ class ShopgateExternalOrder extends ShopgateContainer
      */
     public function setExtraCosts($value)
     {
-        $this->extra_costs = $this->convertArrayToSubentityList($value, 'ShopgateExternalOrderExtraCost');
+        $this->extra_costs = $this->convertArrayToSubEntityList($value, 'ShopgateExternalOrderExtraCost');
     }
 
     /**
@@ -324,7 +328,7 @@ class ShopgateExternalOrder extends ShopgateContainer
      */
     public function setItems($value)
     {
-        $this->items = $this->convertArrayToSubentityList($value, 'ShopgateExternalOrderItem');
+        $this->items = $this->convertArrayToSubEntityList($value, 'ShopgateExternalOrderItem');
     }
 
     /**
@@ -436,7 +440,7 @@ class ShopgateExternalOrder extends ShopgateContainer
     }
 
     /**
-     * @return ShopgateExternalCoupon[]
+     * @return ShopgateExternalOrderExternalCoupon[]
      */
     public function getExternalCoupons()
     {
@@ -921,5 +925,149 @@ class ShopgateExternalOrderTax extends ShopgateContainer
     public function accept(ShopgateContainerVisitor $v)
     {
         $v->visitExternalOrderTax($this);
+    }
+}
+
+class ShopgateExternalOrderExternalCoupon extends ShopgateContainer {
+    protected $code;
+    protected $order_index;
+    protected $name;
+    protected $description;
+    protected $amount;
+    protected $currency;
+    protected $is_free_shipping;
+    protected $internal_info;
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrderIndex()
+    {
+        return $this->order_index;
+    }
+
+    /**
+     * @param int $order_index
+     */
+    public function setOrderIndex($order_index)
+    {
+        $this->order_index = $order_index;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * @return float
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param float $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @param string $currency
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsFreeShipping()
+    {
+        return $this->is_free_shipping;
+    }
+
+    /**
+     * @param bool $is_free_shipping
+     */
+    public function setIsFreeShipping($is_free_shipping)
+    {
+        $this->is_free_shipping = $is_free_shipping;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalInfo()
+    {
+        return $this->internal_info;
+    }
+
+    /**
+     * @param string $internal_info
+     */
+    public function setInternalInfo($internal_info)
+    {
+        $this->internal_info = $internal_info;
+    }
+
+    public function accept(ShopgateContainerVisitor $v)
+    {
+        $v->visitExternalOrderExternalCoupon($this);
     }
 }

--- a/src/items.php
+++ b/src/items.php
@@ -674,7 +674,7 @@ class ShopgateItem extends ShopgateContainer
      */
     public function setOptions($value)
     {
-        $this->options = $this->convertArrayToSubentityList($value, 'ShopgateItemOption');
+        $this->options = $this->convertArrayToSubEntityList($value, 'ShopgateItemOption');
     }
 
     /**
@@ -682,7 +682,7 @@ class ShopgateItem extends ShopgateContainer
      */
     public function setInputs($value)
     {
-        $this->inputs = $this->convertArrayToSubentityList($value, 'ShopgateItemInput');
+        $this->inputs = $this->convertArrayToSubEntityList($value, 'ShopgateItemInput');
     }
 
 
@@ -1174,7 +1174,7 @@ class ShopgateItemOption extends ShopgateContainer
      */
     public function setOptionValues($value)
     {
-        $this->option_values = $this->convertArrayToSubentityList($value, 'ShopgateItemOptionValue');
+        $this->option_values = $this->convertArrayToSubEntityList($value, 'ShopgateItemOptionValue');
     }
 
 

--- a/src/orders.php
+++ b/src/orders.php
@@ -325,7 +325,7 @@ abstract class ShopgateCartBase extends ShopgateContainer
      */
     public function setCustomFields($value)
     {
-        $this->custom_fields = $this->convertArrayToSubentityList($value, 'ShopgateOrderCustomField');
+        $this->custom_fields = $this->convertArrayToSubEntityList($value, 'ShopgateOrderCustomField');
     }
 
     /**
@@ -468,7 +468,7 @@ abstract class ShopgateCartBase extends ShopgateContainer
      */
     public function setExternalCoupons($value)
     {
-        $this->external_coupons = $this->convertArrayToSubentityList($value, 'ShopgateExternalCoupon');
+        $this->external_coupons = $this->convertArrayToSubEntityList($value, 'ShopgateExternalCoupon');
     }
 
     /**
@@ -476,7 +476,7 @@ abstract class ShopgateCartBase extends ShopgateContainer
      */
     public function setShopgateCoupons($value)
     {
-        $this->shopgate_coupons = $this->convertArrayToSubentityList($value, 'ShopgateShopgateCoupon');
+        $this->shopgate_coupons = $this->convertArrayToSubEntityList($value, 'ShopgateShopgateCoupon');
     }
 
     /**
@@ -484,7 +484,7 @@ abstract class ShopgateCartBase extends ShopgateContainer
      */
     public function setItems($value)
     {
-        $this->items = $this->convertArrayToSubentityList($value, 'ShopgateOrderItem');
+        $this->items = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItem');
     }
 
     /**
@@ -950,7 +950,7 @@ class ShopgateOrder extends ShopgateCartBase
      */
     public function setDeliveryNotes($value)
     {
-        $this->delivery_notes = $this->convertArrayToSubentityList($value, 'ShopgateDeliveryNote');
+        $this->delivery_notes = $this->convertArrayToSubEntityList($value, 'ShopgateDeliveryNote');
     }
 
 
@@ -1323,7 +1323,7 @@ class ShopgateOrderItem extends ShopgateContainer
      */
     public function setOptions($value)
     {
-        $this->options = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemOption');
+        $this->options = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemOption');
     }
 
     /**
@@ -1331,7 +1331,7 @@ class ShopgateOrderItem extends ShopgateContainer
      */
     public function setInputs($value)
     {
-        $this->inputs = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemInput');
+        $this->inputs = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemInput');
     }
 
     /**
@@ -1339,7 +1339,7 @@ class ShopgateOrderItem extends ShopgateContainer
      */
     public function setAttributes($value)
     {
-        $this->attributes = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemAttribute');
+        $this->attributes = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemAttribute');
     }
 
 
@@ -2892,7 +2892,7 @@ class ShopgateCartItem extends ShopgateContainer
      */
     public function setOptions($value)
     {
-        $this->options = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemOption');
+        $this->options = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemOption');
     }
 
     /**
@@ -2900,7 +2900,7 @@ class ShopgateCartItem extends ShopgateContainer
      */
     public function setInputs($value)
     {
-        $this->inputs = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemInput');
+        $this->inputs = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemInput');
     }
 
     /**
@@ -2908,7 +2908,7 @@ class ShopgateCartItem extends ShopgateContainer
      */
     public function setAttributes($value)
     {
-        $this->attributes = $this->convertArrayToSubentityList($value, 'ShopgateOrderItemAttribute');
+        $this->attributes = $this->convertArrayToSubEntityList($value, 'ShopgateOrderItemAttribute');
     }
 
     ##########


### PR DESCRIPTION
## Description

The type-hint for `ShopgateExternalOrder::setExternalCoupons()` was hinting to `ShopgateExternalCoupon`, a type for a different purpose. It was kind of usable in this place because is has more fields then required (see docs: http://developers.shopgate.com/plugin_api/orders/get_orders.html).

The ambiguousness caused implementation mistakes because one cannot easily know which fields are required and they're different from the use in check_cart / add_order, where `ShopgateExternalCoupon` had its original purpose.

I added a new class `ShopgateExternalOrderExternalCoupon` that only has the fields documented for this request. The old type is still supported so the change isn't breaking but should give new developers a better direction.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
