### PR TITLE
Allow custom error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - class `ShopgateExternalOrderExternalCoupon`, representing external coupons in the [get_orders documentation](http://developers.shopgate.com/plugin_api/orders/get_orders.html)
+- configuration setting `external_exception_handling` with possible values `catch` (default), `log` or `ignore` [^external_exception_handling-values]
 
 ### Fixed
 - detection of ISO-8859-1 compatible strings as UTF-16LE, leading to them becoming strings with Japanese characters after conversion to UTF-8
 
 ### Changed
 - `ShopgateExternalOrder::setExternalCoupons()` now takes a list of `ShopgateExternalOrderExternalCoupon` objects; `ShopgateExternalCoupon` will still work but is deprecated
-- the `force_source_encoding` flag is now set to true by default, assuming the source encoding to be UTF-8 and effectively disabling auto-detection (*)
-- removed UTF-16LE from the list of possible source encodings (*)
+- the `force_source_encoding` flag is now set to true by default, assuming the source encoding to be UTF-8 and effectively disabling auto-detection [^force_source_encoding-new-default]
+- removed UTF-16LE from the list of possible source encodings [^force_source_encoding-new-default]
 
-(*) These changes were made after a change in PHP 8.1's `mb_string` library made auto-detection work differently.
-    The assumed source encoding can be set via the `encoding` setting of the SDK if you need something different from UTF-8.
+[^external_exception_handling-values]:
+    The new setting should not be user-configurable but be overridden hard-coded by plugins that use their own error handling.<br />
+    It applies only to non-SDK exceptions (i.e. non-`ShopgateLibraryException`, non-`ShopgateMerchantApiException`).<br />
+    Possible values explained:
+    - `catch` (default) - catch uncaught exceptions and transform them to an API response
+    - `log` - log uncaught exceptions and then throw them further up
+    - `ignore` - no handling at all, exceptions just bubble through all the way
+
+[^force_source_encoding-new-default]:
+    These changes were made after a change in PHP 8.1's `mb_string` library made auto-detection work differently.<br />
+    The assumed source encoding can be set via the `encoding` setting of the SDK if you need something different from UTF-8.<br />
     If you need auto-detection back, set `force_source_encoding` back to `0`/`false`.
 
 ## [2.9.89] - 2022-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - class `ShopgateExternalOrderExternalCoupon`, representing external coupons in the [get_orders documentation](http://developers.shopgate.com/plugin_api/orders/get_orders.html)
-- configuration setting `external_exception_handling` with possible values `catch` (default), `log` or `ignore` [^external_exception_handling-values]
+- configuration setting `external_exception_handling` with possible values `catch` (default), `log` or `none` [^external_exception_handling-values]
 
 ### Fixed
 - detection of ISO-8859-1 compatible strings as UTF-16LE, leading to them becoming strings with Japanese characters after conversion to UTF-8
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     Possible values explained:
     - `catch` (default) - catch uncaught exceptions and transform them to an API response
     - `log` - log uncaught exceptions and then throw them further up
-    - `ignore` - no handling at all, exceptions just bubble through all the way
+    - `none` - no handling at all, exceptions just bubble through all the way
 
 [^force_source_encoding-new-default]:
     These changes were made after a change in PHP 8.1's `mb_string` library made auto-detection work differently.<br />

--- a/src/apis.php
+++ b/src/apis.php
@@ -240,8 +240,8 @@ class ShopgatePluginApi extends ShopgateObject implements ShopgatePluginApiInter
         } catch (ShopgateMerchantApiException $e) {
             $error     = ShopgateLibraryException::MERCHANT_API_ERROR_RECEIVED;
             $errortext = ShopgateLibraryException::getMessageFor(
-                    ShopgateLibraryException::MERCHANT_API_ERROR_RECEIVED
-                ) . ': "' . $e->getCode() . ' - ' . $e->getMessage() . '"';
+                ShopgateLibraryException::MERCHANT_API_ERROR_RECEIVED
+            ) . ': "' . $e->getCode() . ' - ' . $e->getMessage() . '"';
         } catch (Exception $e) {
             $message = get_class($e) . " with code: {$e->getCode()} and message: '{$e->getMessage()}'";
 
@@ -1729,8 +1729,8 @@ class ShopgateMerchantApi extends ShopgateObject implements ShopgateMerchantApiI
 
         $opt[CURLOPT_HEADER]         = false;
         $opt[CURLOPT_USERAGENT]      = 'ShopgatePlugin/' . (defined(
-                'SHOPGATE_PLUGIN_VERSION'
-            )
+            'SHOPGATE_PLUGIN_VERSION'
+        )
                 ? SHOPGATE_PLUGIN_VERSION
                 : 'called outside plugin');
         $opt[CURLOPT_RETURNTRANSFER] = true;
@@ -2463,8 +2463,8 @@ class ShopgateAuthenticationServiceOAuth extends ShopgateObject implements Shopg
         $curlOpt = array(
             CURLOPT_HEADER         => false,
             CURLOPT_USERAGENT      => 'ShopgatePlugin/' . (defined(
-                    'SHOPGATE_PLUGIN_VERSION'
-                )
+                'SHOPGATE_PLUGIN_VERSION'
+            )
                     ? SHOPGATE_PLUGIN_VERSION
                     : 'called outside plugin'),
             CURLOPT_SSL_VERIFYPEER => true,
@@ -2511,7 +2511,7 @@ class ShopgateAuthenticationServiceOAuth extends ShopgateObject implements Shopg
             throw new ShopgateLibraryException(
                 ShopgateLibraryException::SHOPGATE_OAUTH_MISSING_ACCESS_TOKEN,
                 (
-                (!empty($decodedResponse['error']) && !empty($decodedResponse['error_description']))
+                    (!empty($decodedResponse['error']) && !empty($decodedResponse['error_description']))
                     ? ' [Shopgate authorization failure "' . $decodedResponse['error'] . '": ' . $decodedResponse['error_description'] . ']'
                     : ' [Shopgate authorization failure: Unexpected server response]'
                 ),
@@ -2586,8 +2586,8 @@ abstract class ShopgatePluginApiResponse extends ShopgateObject
         $this->trace_id      = $traceId;
         $this->version       = $version;
         $this->pluginVersion = (empty($pluginVersion) && defined(
-                'SHOPGATE_PLUGIN_VERSION'
-            ))
+            'SHOPGATE_PLUGIN_VERSION'
+        ))
             ? SHOPGATE_PLUGIN_VERSION
             : $pluginVersion;
     }

--- a/src/apis.php
+++ b/src/apis.php
@@ -264,7 +264,7 @@ class ShopgatePluginApi extends ShopgateObject implements ShopgatePluginApiInter
         $this->logApiError($errortext, $stackTrace);
 
         // if external exception handling is set to logging only, let the original exception bubble up
-        if (!empty($e) && $this->config->getExternalExceptionHandling() === 'log') {
+        if (!empty($e) && $this->config->getExternalExceptionHandling() === ShopgateConfig::EXTERNAL_EXCEPTION_HANDLING_LOG) {
             throw $e;
         }
 

--- a/src/apis.php
+++ b/src/apis.php
@@ -243,7 +243,7 @@ class ShopgatePluginApi extends ShopgateObject implements ShopgatePluginApiInter
                 ShopgateLibraryException::MERCHANT_API_ERROR_RECEIVED
             ) . ': "' . $sge->getCode() . ' - ' . $sge->getMessage() . '"';
         } catch (Exception $e) {
-            if ($this->config->getExternalExceptionHandling() === 'ignore') {
+            if ($this->config->getExternalExceptionHandling() === ShopgateConfig::EXTERNAL_EXCEPTION_HANDLING_NONE) {
                 throw $e;
             }
 
@@ -2953,7 +2953,7 @@ interface ShopgatePluginApiInterface
      *
      * @return bool false if an error occurred, otherwise true.
      *
-     * @throws Exception only if ShopgateConfig::getExternalExceptionHandling() returns "log" or "ignore"
+     * @throws Exception only if ShopgateConfig::getExternalExceptionHandling() returns "log" or "none"
      */
     public function handleRequest(array $data = array());
 

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -35,6 +35,10 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
      */
     const DEFAULT_XSD_URL_LOCATION = 'http://files.shopgate.com/xml/xsd';
 
+    const EXTERNAL_EXCEPTION_HANDLING_CATCH = 'catch';
+    const EXTERNAL_EXCEPTION_HANDLING_LOG = 'log';
+    const EXTERNAL_EXCEPTION_HANDLING_NONE = 'none';
+
     /**
      * @var string The path to the folder where the config file(s) are saved.
      * @deprecated 2.9.69 Use ShopgateConfig::buildConfigFilePath() instead.
@@ -79,10 +83,11 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
     protected $use_custom_error_handler;
 
     /**
-     * @var string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of:
-     *             - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     * @var string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of the
+     *             ShopgateConfig::EXTERNAL_EXCEPTION_HANDLING_* constants:
+     *             - "catch" (default) - catch uncaught exceptions and transform them to an API response
      *             - "log" - log uncaught exceptions and then throw them further up
-     *             - "ignore" - no handling at all
+     *             - "none" - no handling at all
      */
     protected $external_exception_handling;
 
@@ -2949,10 +2954,11 @@ interface ShopgateConfigInterface
     public function getUseCustomErrorHandler();
 
     /**
-     * @return string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of:
-     *                - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     * @return string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of the
+     *                ShopgateConfig::EXTERNAL_EXCEPTION_HANDLING_* constants:
+     *                - "catch" (default) - catch uncaught exceptions and transform them to an API response
      *                - "log" - log uncaught exceptions and then throw them further up
-     *                - "ignore" - no handling at all
+     *                - "none" - no handling at all
      *                This setting applies to all uncaught exceptions that are not a ShopgateLibraryException.
      */
     public function getExternalExceptionHandling();
@@ -3461,10 +3467,10 @@ interface ShopgateConfigInterface
 
     /**
      * @param $value string Handling of uncaught external (i.e. non-ShopgateLibraryException, non-ShopgateMerchantApiException)
-     *                      exceptions. $value can be one of:
-     *                      - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     *                      exceptions. $value can be one of the ShopgateConfig::EXTERNAL_EXCEPTION_HANDLING_* constants:
+     *                      - "catch" (default) - catch uncaught exceptions and transform them to an API response
      *                      - "log" - log uncaught exceptions and then throw them further up
-     *                      - "ignore" - no handling at all
+     *                      - "none" - no handling at all
      *                      This setting applies to all uncaught exceptions that are not a ShopgateLibraryException.
      */
     public function setExternalExceptionHandling($value);

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -59,7 +59,7 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
         'server'          => '/^(live|pg|sl|custom)$/',
         // "live" or "pg" or "sl" or "custom"
         'api_url'         => '/^(https?:\/\/\S+)?$/i',
-        // empty or a string beginning with "http://" or "https://" followed by any number of non-whitespace characters (this is used for testing only, thus the lose validation)
+        // empty or a string beginning with "http://" or "https://" followed by any number of non-whitespace characters (this is used for testing only, thus the loose validation)
     );
 
     /**
@@ -77,6 +77,14 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
      * @var bool true to activate the Shopgate error handler.
      */
     protected $use_custom_error_handler;
+
+    /**
+     * @var string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of:
+     *             - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     *             - "log" - log uncaught exceptions and then throw them further up
+     *             - "ignore" - no handling at all
+     */
+    protected $external_exception_handling;
 
     ##################################################################################
     ### basic shop information necessary for use of the APIs, mobile redirect etc. ###
@@ -534,6 +542,7 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
         // default values
         $this->plugin_name                    = 'not set';
         $this->use_custom_error_handler       = false;
+        $this->external_exception_handling    = 'catch';
         $this->alias                          = 'my-shop';
         $this->cname                          = '';
         $this->server                         = 'live';
@@ -1124,6 +1133,11 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
         return $this->use_custom_error_handler;
     }
 
+    public function getExternalExceptionHandling()
+    {
+        return $this->external_exception_handling;
+    }
+
     //	public function getSpaAuthServiceClassName() {
     //		return $this->spa_auth_service_class_name;
     //	}
@@ -1627,6 +1641,11 @@ class ShopgateConfig extends ShopgateContainer implements ShopgateConfigInterfac
     public function setUseCustomErrorHandler($value)
     {
         $this->use_custom_error_handler = $value;
+    }
+
+    public function setExternalExceptionHandling($value)
+    {
+        $this->external_exception_handling = $value;
     }
 
     //	public function setSpaAuthServiceClassName($value) {
@@ -2929,6 +2948,15 @@ interface ShopgateConfigInterface
      */
     public function getUseCustomErrorHandler();
 
+    /**
+     * @return string Handling of uncaught external (i.e. non-ShopgateLibraryException) exceptions. One of:
+     *                - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     *                - "log" - log uncaught exceptions and then throw them further up
+     *                - "ignore" - no handling at all
+     *                This setting applies to all uncaught exceptions that are not a ShopgateLibraryException.
+     */
+    public function getExternalExceptionHandling();
+
     //	/**
     //	 * @return string $value Class name for the PluginAPI auth service
     //	 */
@@ -3430,6 +3458,16 @@ interface ShopgateConfigInterface
      * @param bool $value true to activate the Shopgate error handler.
      */
     public function setUseCustomErrorHandler($value);
+
+    /**
+     * @param $value string Handling of uncaught external (i.e. non-ShopgateLibraryException, non-ShopgateMerchantApiException)
+     *                      exceptions. $value can be one of:
+     *                      - "catch" (default) - catch uncaught exceptions and transform them to an API response)
+     *                      - "log" - log uncaught exceptions and then throw them further up
+     *                      - "ignore" - no handling at all
+     *                      This setting applies to all uncaught exceptions that are not a ShopgateLibraryException.
+     */
+    public function setExternalExceptionHandling($value);
 
     //	/**
     //	 * @param string $value Class name for the PluginAPI authentication service

--- a/src/core.php
+++ b/src/core.php
@@ -3269,7 +3269,7 @@ abstract class ShopgateContainer extends ShopgateObject
      *
      * Tha data that couldn't be mapped is returned as an array.
      *
-     * @param array <string, mixed> $data The data that should be mapped to the container object.
+     * @param array<string, mixed> $data The data that should be mapped to the container object.
      *
      * @return array<string, mixed> The part of the array that couldn't be mapped.
      */

--- a/src/helper/error_handling/ErrorHandler.php
+++ b/src/helper/error_handling/ErrorHandler.php
@@ -88,7 +88,7 @@ class Shopgate_Helper_Error_Handling_ErrorHandler
         /** @noinspection PhpUnusedParameterInspection */
         array $context = array()
     ) {
-        // on error supression with '@' do not log
+        // on error suppression with '@' do not log
         if ($severity === 0) {
             return $this->skipInternalErrorHandler;
         }


### PR DESCRIPTION
## Description

Adds a new setting allows for custom exception handling outside the SDK workflow for exceptions that are not part of the SDK.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
