### PR TITLE
fix: handle zero length file case in loadKeywordsFromFile function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+* handle zero length file case in loadKeywordsFromFile function
 
 ## [2.10.2] - 2023-10-16
 ### Fixed

--- a/src/redirect.php
+++ b/src/redirect.php
@@ -730,7 +730,8 @@ class ShopgateMobileRedirect extends ShopgateObject implements ShopgateMobileRed
             );
         }
 
-        $keywordsFromFile = explode("\n", @fread($cacheFile, filesize($file)));
+        $filesize = filesize($file);
+        $keywordsFromFile = $filesize > 0 ? explode("\n", @fread($cacheFile, $filesize)) : array();
         @fclose($cacheFile);
 
         /* @phpstan-ignore-next-line */


### PR DESCRIPTION
# Pull Request Template

## Description

This commit introduces a small fix in the `loadKeywordsFromFile` function. Previously, there was an issue wherein zero-length files were not being handled correctly. The fix ensures that the keyword list is exploded only if the file content is not empty.

This will prevent errors or unexpected behaviors when dealing with zero-length files and enhances the stability and reliability of the function.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
